### PR TITLE
Check each iterable element of Contains for substrings

### DIFF
--- a/Rule/Comparator/Contains.php
+++ b/Rule/Comparator/Contains.php
@@ -8,7 +8,7 @@ class Contains extends AbstractComparator
     {
         if (is_array($actual) || $actual instanceof \IteratorAggregate) {
             foreach ($actual as $value) {
-                if ($this->expected == (string) $value) {
+                if (stripos((string) $value, $this->expected) !== false) {
                     return true;
                 }
             }


### PR DESCRIPTION
Rather than an exact string match, this will work with case-insensitive substring check of each element of an iterable
